### PR TITLE
Support Mockito 1.10.9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.16</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/mockito/internal/creation/cglib/GroovyCglibMockMaker.java
+++ b/src/main/java/org/mockito/internal/creation/cglib/GroovyCglibMockMaker.java
@@ -1,10 +1,9 @@
-package com.cyrusinnovation.mockitogroovysupport;
+package org.mockito.internal.creation.cglib;
 
 import org.mockito.cglib.proxy.*;
 import org.mockito.exceptions.base.*;
 import org.mockito.internal.*;
-import org.mockito.internal.creation.*;
-import org.mockito.internal.creation.jmock.*;
+import org.mockito.internal.creation.instance.*;
 import org.mockito.invocation.*;
 import org.mockito.mock.*;
 import org.mockito.plugins.*;
@@ -17,8 +16,10 @@ public class GroovyCglibMockMaker implements MockMaker {
 
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         InternalMockHandler mockitoHandler = cast(handler);
-        return ClassImposterizer.INSTANCE.imposterise(
-                new MethodInterceptorForGroovyFilter(mockitoHandler, settings), settings.getTypeToMock(), settings.getExtraInterfaces());
+        new AcrossJVMSerializationFeature().enableSerializationAcrossJVM(settings);
+        return new ClassImposterizer(new InstantiatorProvider().getInstantiator(settings)).imposterise(
+           new MethodInterceptorForGroovyFilter(mockitoHandler, settings), settings.getTypeToMock(),
+           settings.getExtraInterfaces());
     }
 
     private InternalMockHandler cast(MockHandler handler) {

--- a/src/main/java/org/mockito/internal/creation/cglib/MethodInterceptorForGroovyFilter.java
+++ b/src/main/java/org/mockito/internal/creation/cglib/MethodInterceptorForGroovyFilter.java
@@ -1,9 +1,9 @@
-package com.cyrusinnovation.mockitogroovysupport;
+package org.mockito.internal.creation.cglib;
 
+import com.cyrusinnovation.mockitogroovysupport.ObjectMethodsGroovyGuru;
 import groovy.lang.*;
 import org.mockito.cglib.proxy.*;
 import org.mockito.internal.*;
-import org.mockito.internal.creation.*;
 import org.mockito.mock.*;
 
 import java.lang.reflect.*;

--- a/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,1 @@
-com.cyrusinnovation.mockitogroovysupport.GroovyCglibMockMaker
+org.mockito.internal.creation.cglib.GroovyCglibMockMaker


### PR DESCRIPTION
This is an inelegant solution, but as of 1.10.9, classes that this
depended on became package protected. The simplest fix is to move the
child classes to the same package.

This addresses issue #13